### PR TITLE
Implement interactive selection on contact map

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ __pycache__/
 venv/
 node_modules/
 .vscode/
+venv*/

--- a/src/gtk/css/gtk.css
+++ b/src/gtk/css/gtk.css
@@ -70,7 +70,17 @@ div.gtk { padding: 5px;
 }
 
 .gtkviewcontainer {
-    padding: 5px;
+    position: relative;
+    margin: 5px;
+    line-height: 0;
+}
+
+.gtkoverlay {
+    position: absolute;
+    top: 0;
+    right: 0;
+    bottom: 0;
+    left: 0;
 }
 
 .gtkchartlistcharts {
@@ -97,7 +107,7 @@ div.gtk { padding: 5px;
     height: 500px;
 }
 
-.gtkgeometrycanvas {
+.gtkgeometrycanvas, .gtkviewcanvas {
     border: 1px solid black;
 }
 

--- a/src/gtk/js/GTKContactMapCanvas.js
+++ b/src/gtk/js/GTKContactMapCanvas.js
@@ -31,46 +31,200 @@ THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 /**
  * @class GTKContactMapCanvas
  * 
- * Component displaying contact map data on a canvas.
+ * Component displaying contact map data on a canvas. The user can click-and-drag to select regions
+ * of the data using d3-brush.
+ * 
+ * This creates a div inside the root element specified in the constructor. Inside that div is a
+ * canvas which displays the contact map, and multiple layers of SVG elements which handle mouse
+ * events for selections or contain things like the axes on the side of the map.
+ * 
+ * You can listen to changes in the selection made on the map by assigning a function to
+ * the onSelectionChange property.
  */
 class GTKContactMapCanvas {
 
     /**
      * Create a new GTKContactMapCanvas, appending itself as a child to the element with
      * the specified DOM ID.
+     * 
+     * Once constructed, this will automatically begin fetching and loading the contact map
+     * data in the background. The full widget will appear with everything enabled once loading
+     * has finished.
+     *
      * @param {GTKProject} project The GTKProject this belongs to
      * @param {GTKDataset} dataset The GTKDataset containing the contact map this will display
      * @param {String} rootElemID The DOM ID of the element this will be appended to.
      */
     constructor(project, dataset, rootElemID) {
+        const self = this;
 
         // Build content div
-        let gtkroot  = document.getElementById(rootElemID);
+        /** Div containing all the contents of the contact map widget */
         this.contdiv = document.createElement("div");
         this.contdiv.className = "gtkviewcontainer";
+        const gtkroot  = document.getElementById(rootElemID);
         gtkroot.appendChild(this.contdiv);
 
-        let adata = project.getApplicationData("gtk");
-        let gdata = adata["geometrycanvas"];
-        
-        // Create and add canvas
-        this.canvas = document.createElement("canvas");
-        this.canvas.className = "gtkgeometrycanvas";
-        this.canvas.width  = gdata["width"];
-        this.canvas.height = gdata["height"];
-        this.contdiv.appendChild(this.canvas);
+        // Dimensions
+        /**
+         * Margins separating the canvas from the edges of the widget
+         * (the axes are placed in these margins) 
+         */
+        this.margin = { top: 25, right: 10, bottom: 10, left: 25 };
+        const geom = project.getApplicationData("gtk")["geometrycanvas"];
+        this.margin.innerWidth  = geom["width"]  - ( this.margin.left + this.margin.right  );
+        this.margin.innerHeight = geom["height"] - ( this.margin.top  + this.margin.bottom );
 
+        /**
+         * A d3 selection of the large SVG container.
+         * This contains the x and y axis, but most importantly, it is what enforces the
+         * size of the whole widget. It has an explicit width and height and doesn't have
+         * it's position set to 'absolute' like most of other pieces, so the contdiv
+         * will expand to match this SVG's width and height. 
+         */
+        this.baseSVG = d3.create('svg')
+            .attr('width',  geom["width"] )
+            .attr('height', geom["height"]);
+        this.contdiv.appendChild(this.baseSVG.node());
+
+        // Sets CSS attributes on a selection to make it work
+        // as an overlay that fits within the margins
+        const overlay = g => g
+            .attr('width',  self.margin.innerWidth )
+            .attr('height', self.margin.innerHeight)
+            .attr('style', `
+                position: absolute;
+                top:    ${self.margin.top}px;
+                left:   ${self.margin.left}px;
+                bottom: ${self.margin.bottom}px;
+                right:  ${self.margin.right}px;
+            `);
+
+        /** A d3 selection of the canvas*/
+        this.canvas = d3.create('canvas').call(overlay);
+        this.contdiv.appendChild(this.canvas.node());
+
+        /**
+         * A d3 selection of the overlay SVG.
+         * This is overlayed on top of the canvas and implements the d3-brush for selection
+         * (although the brush won't be added until after has been loded)
+         */
+        this.overlaySVG = d3.create('svg').call(overlay)
+        this.contdiv.appendChild(this.overlaySVG.node());
+
+        // Placeholders for fields that aren't initialized until after
+        // the data loads
+
+        /**
+         * @type {GTKContactMap} The contact map data.
+         * This is null when first constructed, but will be set once data has finished loading
+         */
+        this.contactMap = null;
+        /**
+         * A d3 scale mapping (fractional) bin numbers to pixels on the canvas along the x-axis.
+         * This is null when first constructed, but will be set once data has finished loading
+         */
+        this.xScale = null;
+        /**
+         * A d3 scale mapping (fractional) bin numbers to pixels on the canvas along the y-axis.
+         * This is null when first constructed, but will be set once data has finished loading
+         */
+        this.yScale = null;
+
+        /**
+         * Another class can set this property to enable a listener for when the selection changes.
+         * This will be called as the selection changes with an array of arrays as an argument
+         * formatted like so:
+         * 
+         *      [ [ x1, x2 ], [ y1, y2] ]
+         * 
+         * Where:
+         * 
+         *      x1 is the start of the selected range along the x-axis
+         *      x2 is the end of the selected range along the x-axis
+         *      y1 is the start of the selected range along the y-axis
+         *      y2 is the end of the selected range along the y-axis
+         * 
+         * These values are in terms of bin-number, although they may not be whole numbers
+         * for cases where the user has drawn a selection over just a part of a bin.
+         */
+        this.onSelectionChange = null;
+
+        // Load data
         GTKContactMap.loadNew( dataset.md_contact_mp )
-            .then( (contactMap) => this.renderToImageData(contactMap) )
-            .then( (imageData)  => this.renderToCanvas(imageData)     );
+            .then( (contactMap) => this._afterLoad(contactMap) );
+    }
+
+    /**
+     * Called automatically after contact map data has been loaded
+     * @param {GTKContactMap} contactMap 
+     */
+    _afterLoad(contactMap) {
+        this.contactMap = contactMap;
+
+        // Render canvas
+        this._renderToImageData(contactMap).then( (img) => this._renderToCanvas(img) );
+
+        // Initialize scales
+        const rect = contactMap.bounds;
+        const margin = this.margin;
+        this.xScale = d3.scaleLinear()
+            .domain([ rect.x, rect.x + rect.width    ])
+            .range ([ 0,      this.margin.innerWidth ]);
+        this.yScale = d3.scaleLinear()
+            .domain([ rect.y, rect.y + rect.height    ])
+            .range ([ 0,      this.margin.innerHeight ]);
+
+        // Create and add axes
+        this.baseSVG.append('g')
+            .attr('transform', `translate(${margin.left},${margin.top})`)
+            .call( d3.axisTop(this.xScale) );
+        this.baseSVG.append('g')
+            .attr('transform', `translate(${margin.left},${margin.top})`)
+            .call( d3.axisLeft(this.yScale) );
+
+        // Add brush
+        const brush = d3.brush()
+            .on( 'brush end', (e) => { this._onBrush(e) } );
+        this.overlaySVG.call(brush);
+    }
+
+    /**
+     * Handler for the d3-brush "brush" event, called whenever the
+     * selection changes.
+     * ( call so that 'this' still refers to this GTKContactMapCanvas instance ) 
+     */
+    _onBrush(event) {
+        // If there isn't a handler set, then just forget it
+        if (this.onSelectionChange === undefined) return;
+
+        // event.selection defines the coorindates (in pixels) of the corners of the
+        // selection. We convert that to the extents of the selection along each axis
+        // (in bin numbers)
+
+        let selected;
+
+        if (event.selection === null) {
+            // No selection with the brush is equivalent to just selecting the whole area
+            selected = [ this.xScale.domain(), this.yScale.domain() ]
+        }
+        else {
+            const coords = event.selection.map( ([x,y]) => [ this.xScale.invert(x), this.yScale.invert(y) ]);
+            selected = [
+                [ coords[0][0], coords[1][0] ],
+                [ coords[0][1], coords[1][1] ] 
+            ];
+        }
+
+        this.onSelectionChange(selected);
     }
 
     /**
      * Render a contact map to ImageData
      * @param {GTKContactMap} cm 
-     * @returns {ImageData}
+     * @returns {Promise<ImageData>}
      */
-    renderToImageData(cm) {
+    async _renderToImageData(cm) {
         const pixels = new Uint8ClampedArray(cm.data.length * 4);
 
         for (let i = 0; i < pixels.length; i+= 4) {
@@ -92,16 +246,18 @@ class GTKContactMapCanvas {
      * Render some ImageData to the canvas
      * @param {ImageData} img
      */
-    renderToCanvas(img) {
+    _renderToCanvas(img) {
 
         const tempCanvas = document.createElement("canvas")
         tempCanvas.width  = img.width;
         tempCanvas.height = img.height;
         tempCanvas.getContext('2d').putImageData(img, 0, 0);
 
-        const ctx = this.canvas.getContext('2d');
+        const ctx = this.canvas.node().getContext('2d');
+
+        ctx.scale( this.margin.innerWidth/img.width, this.margin.innerHeight/img.height );
+
         ctx.imageSmoothingEnabled = false;
-        ctx.scale( this.canvas.width/img.width, this.canvas.height/img.height );
         ctx.drawImage(tempCanvas, 0, 0);
     }
 

--- a/src/gtk/js/GTKGeometryCanvas.js
+++ b/src/gtk/js/GTKGeometryCanvas.js
@@ -75,7 +75,7 @@ class GTKGeometryCanvas {
         // gtkroot.appendChild(groot);
 
         var contdiv = document.createElement("div");
-        contdiv.className = "gtkgeometrycontainer";
+        contdiv.className = "gtkviewcontainer";
         gtkroot.appendChild(contdiv);
 
         var canvas_idstring = "gtkgeometry-" + this.dataset.id.toString();

--- a/src/gtk/js/viewer.js
+++ b/src/gtk/js/viewer.js
@@ -34,7 +34,28 @@ function main( project ) {
     var dset = project.getDatasets(); 
     var dataset = new GTKDataset(dset[0]);
     view = new GTKGeometryCanvas( project, dataset, "structureview" );
-    new GTKContactMapCanvas( project, dataset, "contactmapview" )
+
+    const contactMap = new GTKContactMapCanvas( project, dataset, "contactmapview" )
+
+    // Update view when selection in contact map changes
+    contactMap.onSelectionChange = function(selection) {
+        const segments = {};
+        const [ [x1,x2], [y1,y2] ] = selection; // start/end coordinates for the selection on each axis
+
+        for (let i = Math.floor(x1); i <= Math.ceil(x2); i++ ) {
+            if (!segments[i])
+                segments[i] = true;
+        }
+        for (let i = Math.floor(y1); i <= Math.ceil(y2); i++ ) {
+            if (!segments[i])
+                segments[i] = true;
+        }
+
+        const ids = Object.keys(segments).map( d => parseInt(d) );
+        view.setSegmentStates( ids, GTKSegmentState.LIVE, GTKSegmentState.GHOST );
+        view.render();
+
+    };
 }
 
 function setState() {

--- a/src/viewer.html
+++ b/src/viewer.html
@@ -11,6 +11,9 @@
     <link rel="stylesheet" href="https://cdn.jsdelivr.net/chartist.js/latest/chartist.min.css">
     <script src="https://cdn.jsdelivr.net/chartist.js/latest/chartist.min.js"></script>
 
+    <!--d3-->
+    <script src="https://d3js.org/d3.v7.min.js"></script>
+
     <link rel="stylesheet" href="gtk/css/ct-custom.css">
     <link rel="stylesheet" href="gtk/css/gtk.css">
     <link rel="stylesheet" href="gtk/css/gtkslider.css">


### PR DESCRIPTION
This PR continues to address issue #1. This enables interactive selection on the contact map via [D3 Brush](https://github.com/d3/d3-brush). Clicking-and-dragging an area on the contact map will highlight the corresponding area in the geometry view.

Currently, the interaction is implemented using a listener in `viewer.js`, but at a later stage, we'll probably want to adopt something more in-line with the usual event API. Also, the listener right now scales linearly with the size of the selection. That isn't a problem for the tiny testing data set, but larger data sets may lag. To fix it, we would need to re-work how the `setSegmentStates` method of `GTKGeometryCanvas` takes its input.

Next steps are:
- Zooming and Panning of the contact map view
- Multiple selections
- Writing tests for all the new code