### PR TITLE
Contact Map can zoom/pan and also has settings in project.json

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -5,7 +5,7 @@
     "version": "0.2.0",
     "configurations": [
         {
-            "name": "Launch Localhost",
+            "name": "test.00",
             "type": "firefox",
             "request": "launch",
             "reAttach": true,
@@ -13,5 +13,14 @@
             "clearConsoleOnReload": true,
             "webRoot": "${workspaceFolder}/src/"
         },
+        {
+            "name": "test.01",
+            "type": "firefox",
+            "request": "launch",
+            "reAttach": true,
+            "url": "http://localhost:8000/viewer.html?gtkproject=test.01",
+            "clearConsoleOnReload": true,
+            "webRoot": "${workspaceFolder}/src/"
+        }
     ]
 }

--- a/projects/test.00/project.json
+++ b/projects/test.00/project.json
@@ -148,6 +148,10 @@
             "name": "viewer",
             "version" : "0.5"
         },
+        "contactmapcanvas": {
+            "width": 500,
+            "height": 500
+        },
         "geometrycanvas" : {
             "width":  600, 
             "height": 500,

--- a/src/gtk/css/gtk.css
+++ b/src/gtk/css/gtk.css
@@ -153,8 +153,23 @@ div.gtk { padding: 5px;
     padding-right:  5px;
     padding-bottom: 10px;
     padding-left:   0px;
-}
+} 
 
 .gtkbodytable {
     font-size: 20px;
+}
+
+.gtkviewcontainer .zoomsvg {
+    border-style: solid;
+    transition: border-color 0.2s;
+}
+
+.gtkviewcontainer .zoomsvg[pointer-events=none] {
+    border-color: transparent;
+    cursor: grab;
+}
+
+.gtkviewcontainer .zoomsvg[pointer-events=all] {
+    border-color: steelblue;
+    cursor: grab;
 }

--- a/src/gtk/js/GTKContactMapCanvas.js
+++ b/src/gtk/js/GTKContactMapCanvas.js
@@ -31,17 +31,49 @@ THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 /**
  * @class GTKContactMapCanvas
  * 
- * Component displaying contact map data on a canvas. The user can click-and-drag to select regions
- * of the data using d3-brush.
+ * Widget displaying contact map data on a canvas.
  * 
- * This creates a div inside the root element specified in the constructor. Inside that div is a
- * canvas which displays the contact map, and multiple layers of SVG elements which handle mouse
- * events for selections or contain things like the axes on the side of the map.
+ * The user can click-and-drag on the image to select a region of the contact map. If the user holds
+ * down the spacebar, then they can use the scroll wheel to zoom in or out of the image and
+ * click-and-drag to pan across it.
  * 
  * You can listen to changes in the selection made on the map by assigning a function to
  * the onSelectionChange property.
  */
 class GTKContactMapCanvas {
+
+    /**
+     * The DOM layout of the widget looks like this:
+     *      div (this.contdiv)
+     *          - svg (this.baseSVG)
+     *              - g (xaxis)
+     *              - g (yaxis)
+     *          - canvas
+     *          - svg (this.brushSVG)
+     *          - svg (this.zoomSVG)
+     * 
+     * Click-and-drag selection, and zooming/panning are implemented using D3's brush and zoom
+     * tools respectively. However, brush and zoom aren't normally designed to work together, so
+     * a work-around is used:
+     * 
+     * The SVG element which handles zooming is overlayed on top of the SVG that handles brushing,
+     * but has it's 'pointer-events' attribute set to 'none'. So, by default, mouse events go
+     * through the zoomSVG and are recieved by the brushSVG, meaning that clicking and dragging over
+     * the canvas will create a selection with the brush. When this script is loaded, it adds
+     * 'keyup' and 'keydown' event listeners to the whole window which will listen for a particular
+     * key (in this case, the spacebar) and toggle the 'pointer-events' attribute on the zoomSVG
+     * of all active instances of this class to 'all'. So, while the spacebar is held down, mouse
+     * events are recieved by the zoomSVG and now clicking and dragging over the canvas will pan
+     * the viewport, while scrolling with zoom in or out.
+     * 
+    */
+
+    /**
+     * An array of (weak references to) all of the instances of this class.
+     * Used to globally toggle zoom controls (which are controlled by a global
+     * event listener)
+     */
+    static instances = [];
 
     /**
      * Create a new GTKContactMapCanvas, appending itself as a child to the element with
@@ -68,9 +100,9 @@ class GTKContactMapCanvas {
         // Dimensions
         /**
          * Margins separating the canvas from the edges of the widget
-         * (the axes are placed in these margins) 
+         * (the axes are placed in these margins)
          */
-        this.margin = { top: 25, right: 10, bottom: 10, left: 25 };
+        this.margin = { top: 25, right: 25, bottom: 25, left: 25 };
         const geom = project.getApplicationData("gtk")["geometrycanvas"];
         this.margin.innerWidth  = geom["width"]  - ( this.margin.left + this.margin.right  );
         this.margin.innerHeight = geom["height"] - ( this.margin.top  + this.margin.bottom );
@@ -79,8 +111,8 @@ class GTKContactMapCanvas {
          * A d3 selection of the large SVG container.
          * This contains the x and y axis, but most importantly, it is what enforces the
          * size of the whole widget. It has an explicit width and height and doesn't have
-         * it's position set to 'absolute' like most of other pieces, so the contdiv
-         * will expand to match this SVG's width and height. 
+         * it's position set to 'absolute' like most other pieces, so the contdiv
+         * will expand to match this SVG's width and height.
          */
         this.baseSVG = d3.create('svg')
             .attr('width',  geom["width"] )
@@ -104,13 +136,26 @@ class GTKContactMapCanvas {
         this.canvas = d3.create('canvas').call(overlay);
         this.contdiv.appendChild(this.canvas.node());
 
-        /**
-         * A d3 selection of the overlay SVG.
-         * This is overlayed on top of the canvas and implements the d3-brush for selection
-         * (although the brush won't be added until after has been loded)
-         */
-        this.overlaySVG = d3.create('svg').call(overlay)
-        this.contdiv.appendChild(this.overlaySVG.node());
+        /** A d3 selection of a text label displaying help to the user */
+        this.helpLabel = d3.create('span')
+            .attr('style', `
+                position: absolute;
+                bottom: 5px;
+                left: ${self.margin.left + 10}px;
+            `)
+            .text("Click-and-drag to select. Hold Space to zoom & pan");
+        this.contdiv.appendChild(this.helpLabel.node());
+
+        /** A d3 selection of the SVG handling brush selection */
+        this.brushSVG = d3.create('svg').call(overlay)
+            .classed('brushsvg', true);
+            this.contdiv.appendChild(this.brushSVG.node());
+            
+            /** A d3 selection of the SVG handling zooming/panning */
+            this.zoomSVG = d3.create('svg').call(overlay)
+            .classed('zoomsvg', true)
+            .attr('pointer-events', 'none');
+        this.contdiv.appendChild(this.zoomSVG.node());
 
         // Placeholders for fields that aren't initialized until after
         // the data loads
@@ -120,6 +165,13 @@ class GTKContactMapCanvas {
          * This is null when first constructed, but will be set once data has finished loading
          */
         this.contactMap = null;
+
+        /**
+         * @type {ImageData} The contact map rendered to ImageData (one pixel per bin)
+         * This is null when first constructed, but will be set once data has finished loading
+         */
+        this.imageData = null;
+
         /**
          * A d3 scale mapping (fractional) bin numbers to pixels on the canvas along the x-axis.
          * This is null when first constructed, but will be set once data has finished loading
@@ -130,6 +182,32 @@ class GTKContactMapCanvas {
          * This is null when first constructed, but will be set once data has finished loading
          */
         this.yScale = null;
+
+        /**
+         * A d3 scale mapping (fractional) bin numbers to pixels on the canvas along the x-axis.
+         * This scale doesn't take into account zooming or panning, and always represents the
+         * scale used when fully zoomed-out.
+         * This is null when first constructed, but will be set once data has finished loading
+         */
+        this.xScaleOriginal = null;
+
+        /**
+         * A d3 scale mapping (fractional) bin numbers to pixels on the canvas along the y-axis.
+         * This scale doesn't take into account zooming or panning, and always represents the
+         * scale used when fully zoomed-out.
+         * This is null when first constructed, but will be set once data has finished loading
+         */
+        this.yScaleOriginal = null;
+
+        /**
+         * A d3-brush function used to handle click-and-drag selection
+         */
+        this.brush = null;
+
+        /**
+         * A d3-zoom function used to handle zooming and panning
+         */
+        this.zoom = null;
 
         /**
          * Another class can set this property to enable a listener for when the selection changes.
@@ -153,6 +231,9 @@ class GTKContactMapCanvas {
         // Load data
         GTKContactMap.loadNew( dataset.md_contact_mp )
             .then( (contactMap) => this._afterLoad(contactMap) );
+
+        // Add to global list of instances
+        GTKContactMapCanvas.instances.push( new WeakRef(this) );
     }
 
     /**
@@ -162,31 +243,55 @@ class GTKContactMapCanvas {
     _afterLoad(contactMap) {
         this.contactMap = contactMap;
 
-        // Render canvas
-        this._renderToImageData(contactMap).then( (img) => this._renderToCanvas(img) );
+        // Render image
+        this.imageData = this._renderToImageData(contactMap);
 
-        // Initialize scales
         const rect = contactMap.bounds;
         const margin = this.margin;
-        this.xScale = d3.scaleLinear()
+
+        // Initialize scales
+        this.xScaleOriginal = d3.scaleLinear()
             .domain([ rect.x, rect.x + rect.width    ])
             .range ([ 0,      this.margin.innerWidth ]);
-        this.yScale = d3.scaleLinear()
+        this.yScaleOriginal = d3.scaleLinear()
             .domain([ rect.y, rect.y + rect.height    ])
             .range ([ 0,      this.margin.innerHeight ]);
 
+        this.xScale = this.xScaleOriginal.copy();
+        this.yScale = this.yScaleOriginal.copy();
+
         // Create and add axes
         this.baseSVG.append('g')
+            .classed('xaxis', true)
             .attr('transform', `translate(${margin.left},${margin.top})`)
             .call( d3.axisTop(this.xScale) );
         this.baseSVG.append('g')
+            .classed('yaxis', true)
             .attr('transform', `translate(${margin.left},${margin.top})`)
             .call( d3.axisLeft(this.yScale) );
 
+        const MAX_ZOOM = 10;
+
         // Add brush
-        const brush = d3.brush()
+        this.brush = d3.brush()
+            // the brush extents are sized to fit the entire contact map even when
+            // zoomed in all the way. That way, brushes can be moved outside of the viewport
+            // when zooming and panning
+            .extent([
+                [ -margin.innerWidth * (MAX_ZOOM-1), -margin.innerHeight * (MAX_ZOOM-1) ],
+                [ margin.innerWidth * MAX_ZOOM,      margin.innerHeight * MAX_ZOOM ]
+            ])
             .on( 'brush end', (e) => { this._onBrush(e) } );
-        this.overlaySVG.call(brush);
+        this.brushSVG.call(this.brush);
+
+        // Add zoom
+        this.zoom = d3.zoom()
+            .scaleExtent([1, MAX_ZOOM])
+            .translateExtent([ [0,0], [margin.innerWidth, margin.innerHeight] ])
+            .on( 'zoom', (e) => { this._onZoom(e) } );
+        this.zoomSVG.call(this.zoom);
+
+        this._redrawCanvas();
     }
 
     /**
@@ -198,33 +303,77 @@ class GTKContactMapCanvas {
         // If there isn't a handler set, then just forget it
         if (this.onSelectionChange === undefined) return;
 
+        // Ignore if the brush moved as a result of panning or zooming
+        if (event.sourceEvent && event.sourceEvent.type === 'zoom') return;
+
         // event.selection defines the coorindates (in pixels) of the corners of the
         // selection. We convert that to the extents of the selection along each axis
         // (in bin numbers)
 
+        const selection = event.selection;
         let selected;
 
-        if (event.selection === null) {
+        if (selection === null) {
             // No selection with the brush is equivalent to just selecting the whole area
-            selected = [ this.xScale.domain(), this.yScale.domain() ]
+            selected = [ this.xScaleOriginal.domain(), this.yScaleOriginal.domain() ]
         }
         else {
-            const coords = event.selection.map( ([x,y]) => [ this.xScale.invert(x), this.yScale.invert(y) ]);
+            const coords = this._scaleBrushSelection(selection, this.xScale.invert, this.yScale.invert);
             selected = [
                 [ coords[0][0], coords[1][0] ],
-                [ coords[0][1], coords[1][1] ] 
+                [ coords[0][1], coords[1][1] ]
             ];
         }
+
+        // Clamp selection to boundaries
+        const rect = this.contactMap.bounds;
+        selected[0][0] = Math.max( rect.x,                   selected[0][0] );
+        selected[0][1] = Math.min( rect.x + rect.width - 1,  selected[0][1] )
+        selected[1][0] = Math.max( rect.y,                   selected[1][0] );
+        selected[1][1] = Math.min( rect.y + rect.height - 1, selected[1][1] )
+
+        //console.log(`Selection: (X: ${selected[0][0]} - ${selected[0][1]} ) (Y: ${selected[1][0]} - ${selected[1][1]} )`)
 
         this.onSelectionChange(selected);
     }
 
     /**
+     * Handler for the d3-zoom "zoom" event, called whenever the viewport
+     * is zoomed or panned.
+     * ( call so that 'this' still refers to this GTKContactMapCanvas instance )
+     */
+    _onZoom(event) {
+        const trans = event.transform;
+
+        // Get brush selection
+        let selection = d3.brushSelection( this.brushSVG.node() );
+        if (selection !== null) {
+            selection = this._scaleBrushSelection(selection, this.xScale.invert, this.yScale.invert);
+        }
+
+        // Transform scales
+        this.xScale = trans.rescaleX(this.xScaleOriginal);
+        this.yScale = trans.rescaleY(this.yScaleOriginal);
+
+        // Move brush to new position after transformation
+        if (selection !== null) {
+            selection = this._scaleBrushSelection(selection, this.xScale, this.yScale);
+            this.brush.move( this.brushSVG, selection, event );
+        }
+
+        // Redraw axes
+        this.baseSVG.select('.xaxis').call( d3.axisTop(this.xScale) );
+        this.baseSVG.select('.yaxis').call( d3.axisLeft(this.yScale) );
+
+        this._redrawCanvas();
+    }
+
+    /**
      * Render a contact map to ImageData
      * @param {GTKContactMap} cm 
-     * @returns {Promise<ImageData>}
+     * @returns {ImageData}
      */
-    async _renderToImageData(cm) {
+    _renderToImageData(cm) {
         const pixels = new Uint8ClampedArray(cm.data.length * 4);
 
         for (let i = 0; i < pixels.length; i+= 4) {
@@ -243,10 +392,12 @@ class GTKContactMapCanvas {
     }
 
     /**
-     * Render some ImageData to the canvas
-     * @param {ImageData} img
+     * Repaint the contact map onto the canvas.
+     * Should call this any time the viewport is zoomed or panned
      */
-    _renderToCanvas(img) {
+    _redrawCanvas() {
+        const img = this.imageData;
+        if (img === null) return;
 
         const tempCanvas = document.createElement("canvas")
         tempCanvas.width  = img.width;
@@ -254,11 +405,52 @@ class GTKContactMapCanvas {
         tempCanvas.getContext('2d').putImageData(img, 0, 0);
 
         const ctx = this.canvas.node().getContext('2d');
+        ctx.clearRect(0, 0, this.margin.innerWidth, this.margin.innerHeight);
+        ctx.save();
+
+        const trans = d3.zoomTransform(this.zoomSVG.node());
+        ctx.translate(trans.x, trans.y);
+        ctx.scale(trans.k, trans.k);
 
         ctx.scale( this.margin.innerWidth/img.width, this.margin.innerHeight/img.height );
 
         ctx.imageSmoothingEnabled = false;
         ctx.drawImage(tempCanvas, 0, 0);
+
+        ctx.restore();
+    }
+
+    /**
+     * Given a selection from a d3 brush, return a selection scaled according
+     * to the given scales for x/y axes.
+     */
+    _scaleBrushSelection(selection, xScale, yScale) {
+        return selection.map( ([x,y]) => [ xScale(x), yScale(y) ] );
     }
 
 }
+
+// Add a global key event listener which will toggle the
+// 'pointer-events' attribute on the zoomSVG of all instances
+addEventListener('keydown', (event) => {
+    if (event.key !== ' ' && !event.repeat) return;
+
+    GTKContactMapCanvas.instances = GTKContactMapCanvas.instances.filter( (d) => d.deref() !== undefined );
+    for (let instance of GTKContactMapCanvas.instances) {
+        const component = instance.deref();
+
+        component.zoomSVG.attr('pointer-events', 'all');
+    }
+});
+
+addEventListener('keyup', (event) => {
+    if (event.key !== ' ' && !event.repeat) return;
+
+    GTKContactMapCanvas.instances = GTKContactMapCanvas.instances.filter( (d) => d.deref() !== undefined );
+    for (let instance of GTKContactMapCanvas.instances) {
+        const component = instance.deref();
+
+        component.zoomSVG.attr('pointer-events', 'none');
+
+    }
+});

--- a/src/gtk/js/GTKContactMapCanvas.js
+++ b/src/gtk/js/GTKContactMapCanvas.js
@@ -98,14 +98,19 @@ class GTKContactMapCanvas {
         gtkroot.appendChild(this.contdiv);
 
         // Dimensions
+
+        /**
+         * Display options for the canvas (as defined in the project configuration)
+         */
+        this.displayOpts = project.getApplicationData("gtk")["contactmapcanvas"];
+
         /**
          * Margins separating the canvas from the edges of the widget
          * (the axes are placed in these margins)
          */
         this.margin = { top: 25, right: 25, bottom: 25, left: 25 };
-        const geom = project.getApplicationData("gtk")["geometrycanvas"];
-        this.margin.innerWidth  = geom["width"]  - ( this.margin.left + this.margin.right  );
-        this.margin.innerHeight = geom["height"] - ( this.margin.top  + this.margin.bottom );
+        this.margin.innerWidth  = this.displayOpts["width"]  - ( this.margin.left + this.margin.right  );
+        this.margin.innerHeight = this.displayOpts["height"] - ( this.margin.top  + this.margin.bottom );
 
         /**
          * A d3 selection of the large SVG container.
@@ -115,8 +120,8 @@ class GTKContactMapCanvas {
          * will expand to match this SVG's width and height.
          */
         this.baseSVG = d3.create('svg')
-            .attr('width',  geom["width"] )
-            .attr('height', geom["height"]);
+            .attr('width',  this.displayOpts["width"] )
+            .attr('height', this.displayOpts["height"]);
         this.contdiv.appendChild(this.baseSVG.node());
 
         // Sets CSS attributes on a selection to make it work
@@ -376,10 +381,12 @@ class GTKContactMapCanvas {
     _renderToImageData(cm) {
         const pixels = new Uint8ClampedArray(cm.data.length * 4);
 
+        const magnification = this.displayOpts["magnify"] || 1;
+
         for (let i = 0; i < pixels.length; i+= 4) {
             const val = cm.data[i/4];
 
-            const normalized = (val - cm.minValue) / (cm.maxValue - cm.minValue);
+            const normalized = (val - cm.minValue) / (cm.maxValue - cm.minValue) * magnification;
 
             // color scale from white to red
             pixels[i]   = 255;                // red


### PR DESCRIPTION
More progress towards issue #1:

This PR encompasses two key changes:

1. You can zoom in and out of the contact map canvas and pan the viewport while zoomed in. Clicking and dragging still creates a selection as before, but now holding down the spacebar will enable zoom/pan. Use the scroll wheel to zoom, then click and drag to pan the canvas.

2. The contact map widget now has its own settings in the `project.json` files. It has options for `width` and `height`, as well as an option, `magnify`, which multiplies all the values shown on the canvas by some amount, making differences easier to see.