### PR TITLE
Update clients for production server, and fix tests

### DIFF
--- a/.github/workflows/client.yml
+++ b/.github/workflows/client.yml
@@ -37,4 +37,4 @@ jobs:
         python3 release/test.00/server/gtkserver.py &
         sleep 5
         ls -la
-        pytest testing/test_gentk.py 
+        pytest testing/test_gentk_debug.py 

--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@ projects/test.01/
 projects/test.02/
 projects/test.00/generated/
 projects/release.2021-09-15
+projects/release.2021-09-15.05-19
 __pycache__/
 venv/
 node_modules/
@@ -11,8 +12,8 @@ node_modules/
 venv*/
 client-py/dist/
 client-py/build/
-client-py/*.egg-info
+*.egg-info
 client-js/gtk-dist/
 gtk.min.js
-./gtkclient_*_test.json
+gtkclient_*_test.json
 testing/scratch

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -5,6 +5,13 @@
     "version": "0.2.0",
     "configurations": [
         {
+            "name": "gtkserver test.00",
+            "type": "python",
+            "request": "launch",
+            "program": "${workspaceFolder}/release/test.00/server/gtkserver.py",
+            "console": "integratedTerminal"
+        },
+        {
             "name": "Test Server",
             "type": "firefox",
             "request": "launch",

--- a/client-js/GTK/Client.js
+++ b/client-js/GTK/Client.js
@@ -10,8 +10,12 @@ class Client {
 
     static TheClient = null;
 
-    constructor( host ) {
+    constructor( host, options ) {
         this.host = host;
+
+        if (options && options.auth) {
+            this.auth = `Basic ${Buffer.from(options.auth).toString("base64")}`
+        }
     }
 
     set data(d) {
@@ -23,8 +27,14 @@ class Client {
     }
 
     _fetch(path, callback) {
-        const url = this.host !== undefined ? new URL(path, this.host) : path; 
-        fetch(url)
+        const url = this.host !== undefined ? new URL(path, this.host) : path;
+        const options = this.auth ? {
+            headers: {
+                'Authorization': this.auth
+            }
+        } : undefined;
+
+        fetch(url, options)
             .then(response => response.json())
             .then(data => callback(data));
     }
@@ -33,9 +43,7 @@ class Client {
     // get the project interval 
     //
     get_project_interval(callback) {
-        fetch( this.url + ':' + this.port + '/project/interval' )
-            .then(response => response.json())
-            .then(data => callback(data))
+        this._fetch('/project/interval', callback)
     }
 
     //
@@ -49,18 +57,14 @@ class Client {
     // get metadata for a gene
     //
     get_gene_metadata(callback, gene) {
-        fetch( this.url + ':' + this.port + '/gene/' + gene )
-            .then(response => response.json())
-            .then(data => callback(data))
+        this._fetch(`/gene/${gene}`, callback)
     }
 
     //
     // get the genes for a list of segments 
     //
     get_genes_for_locations(callback, sid, locations) {
-        fetch( this.url + ':' + this.port + '/data/structure/' + sid + '/locations/' + locations + '/genes' )
-            .then(response => response.json())
-            .then(data => callback(data))
+        this._fetch(`/data/structure/${sid}/locations/${locations}/genes`, callback)
     }
 
     //

--- a/server/Dockerfile
+++ b/server/Dockerfile
@@ -122,6 +122,7 @@ RUN  echo "from gtkserver import app as application" > /srv/app.wsgi
 # symlink here.
 RUN ln -sf /dev/stderr /var/log/apache2/error.log
 
+RUN chown -R www-data:www-data /srv
 WORKDIR /srv
 
 EXPOSE 443

--- a/testing/client-js.test.js
+++ b/testing/client-js.test.js
@@ -7,7 +7,7 @@ var fs = require('fs');
 //
 test('client test', () => {
     // test.00
-    client = new Client("http://127.0.0.1", 8000);
+    client = new Client("http://127.0.0.1:8000");
 
     client.get_structure_arrays( (response) => {
                             var streamname = "gtkclient_get-structure-arrays_test.json";

--- a/testing/test_gentk_debug.py
+++ b/testing/test_gentk_debug.py
@@ -1,0 +1,4 @@
+import gentk
+from .testfunctions import *
+
+set_client( gentk.client.client("http://127.0.0.1", "8000"), "test.00" )

--- a/testing/test_gentk_production.py
+++ b/testing/test_gentk_production.py
@@ -1,0 +1,11 @@
+import gentk
+from .testfunctions import *
+
+import os
+
+CERT_FILE = os.path.join(
+    os.path.dirname(__file__), '..', 'server', 'example', 'ssl', 'cert.pem'
+)
+os.environ['REQUESTS_CA_BUNDLE'] = CERT_FILE
+
+set_client( gentk.client.client("https://localhost", "4430", auth="user:password"), "test.00" )

--- a/testing/testfunctions.py
+++ b/testing/testfunctions.py
@@ -1,7 +1,14 @@
-import gentk
+#
+# Imported by the test_gentk.py and test_gentk_production.py scripts
+#
 
-client = gentk.client.client("http://127.0.0.1", "8000")
-client.project = "test.00"
+client = None
+
+def set_client(new_client, project):
+    global client
+    client = new_client
+    client.project = project
+
 
 def test_get_contactmap():
     tests = [
@@ -371,4 +378,3 @@ def test_get_datset_ids():
     for t in tests:
         ids = client.get_dataset_ids()
         assert(t['ids'] == ids)
-


### PR DESCRIPTION
This PR updates the two client programs (GTK/Client.js for Javascript, gentk for Python) to be compatible with the production version of the server (i.e. they can now use HTTPS and basic authentication).

For the Python client, you need only include the `https://` in the url, and also include the `auth` keyword argument to the client constructor. The `auth` argument takes a string the username and password separated by a colon (`:`).

Example: `gentk.client.client('https://localhost', 443, auth="cameron:mypassword")`

**PLEASE NOTE:** The changes to the Javascript client are _not_ backwards compatible. The hostname and port are now specified together in a single argument (just include the port in the url). To include basic auth, add an additional object to the arguments with an `auth` field specifying the username and password (as a colon-separated string).

Example: `new Client('https://localhost:443', { auth: "cameron:mypassword" })`

When running the browser, none of this necessary. Instead, simply give _no_ arguments to the Client constructor and the browser will simply fetch from the same origin as the website.

Example: `new Client()`

This PR also updates the test scripts and workflows so that they work with these changes. There's a new test script `test_gentk_production.py` which tests against the production server, although it's not currently part of any GitHub actions workflow, so you need to manually build and set-up the container before running it.