### PR TITLE
Contact Map widgets sync with ControlPanel and each-other

### DIFF
--- a/client-js/GTK/ViewerPanel.js
+++ b/client-js/GTK/ViewerPanel.js
@@ -60,22 +60,24 @@ class ViewerPanel {
         this.contactmapcanvas = new ContactMapCanvas( project, dataset, cm_elem.id )
 
         // Update view when selection in contact map changes
-        this.contactmapcanvas.onSelectionChange = (function(selection) {
-            const segments = {};
-            const [ [x1,x2], [y1,y2] ] = selection; // start/end coordinates for the selection on each axis
-
-            for (let i = Math.floor(x1); i <= Math.ceil(x2); i++ ) {
-                if (!segments[i])
-                    segments[i] = true;
-            }
-            for (let i = Math.floor(y1); i <= Math.ceil(y2); i++ ) {
-                if (!segments[i])
-                    segments[i] = true;
-            }
-            const ids = Object.keys(segments).map( d => parseInt(d) );
-            this.geometrycanvas.setSegmentStates( ids, Segment.State.LIVE, Segment.State.GHOST );
+        this.contactmapcanvas.addListener('selectionChanged', (function(selection) {
+            this.geometrycanvas.setSegmentStates( selection, Segment.State.LIVE, Segment.State.GHOST );
             this.geometrycanvas.render();
-        }).bind(this);
+        }).bind(this) );
+    }
+
+    /**
+     * Sets the selection within this panel's GeometryCanvas and ContactMapCanvas. It will *NOT*
+     * trigger the event listeners for either.
+     * 
+     * 'segments' is an array of segment IDs, specifying the segments that are included in the
+     * selection.
+     * @param {Number[]} segments 
+     */
+    setSelection(segments) {
+        this.geometrycanvas.setSegmentStates( segments, Segment.State.LIVE, Segment.State.GHOST );
+        this.geometrycanvas.render();
+        this.contactmapcanvas.setSelection(segments);
     }
 
 }

--- a/server/static/gtk/js/compare.js
+++ b/server/static/gtk/js/compare.js
@@ -139,6 +139,7 @@ function segmentChanged(e) {
     for (let i = 0; i < TheNumPanels; i++) {
         ThePanels[i].geometrycanvas.geometry.setSegmentStates( segments, GTK.Segment.State.LIVE, GTK.Segment.State.GHOST );
         ThePanels[i].geometrycanvas.render();
+        ThePanels[i].contactmapcanvas.setSelection(segments);
     }
 }
 
@@ -149,6 +150,7 @@ function locationChanged(e) {
     for (let i = 0; i < TheNumPanels; i++) {
         ThePanels[i].geometrycanvas.geometry.setSegmentStates( segments, GTK.Segment.State.LIVE, GTK.Segment.State.GHOST );
         ThePanels[i].geometrycanvas.render();
+        ThePanels[i].contactmapcanvas.setSelection(segments);
     }
 }
 
@@ -157,6 +159,7 @@ function geneChanged(e) {
         GTK.Client.TheClient.get_segments_for_genes( (response) => {
                 ThePanels[i].geometrycanvas.geometry.setSegmentStates( response["segments"], GTK.Segment.State.LIVE, GTK.Segment.State.GHOST );
                 ThePanels[i].geometrycanvas.render();
+                ThePanels[i].contactmapcanvas.setSelection( response["segments"]);
             }, i, e); 
     }
 }


### PR DESCRIPTION
With this PR, selections made in the ControlPanel widget will be reflected in both of the ContactMap widgets, and moving the selection in one ContactMap will move it in the other.

There was some refactoring done in the second commit. You can read about it in the full commit message, but the short version is this:

The GeometryCanvas and ContactMapCanvas widgets now report and accept selections in the same format (with ContactMap taking on the extra complexity and inefficiency to match GeometryCanvas's format). This could be a problem in the future with really large data sets, and could be a problem _now_ if you consider ugly code a problem. Once this sprint is done with, we should take the time to work out how all the components are going to communicate selections with one-another and find something that works the best for all components. Probably through the introduction of a dedicated type representing a selection (different than what the Selection class does now).