### PR TITLE
Remove gid

### DIFF
--- a/bin/db_pop
+++ b/bin/db_pop
@@ -227,10 +227,10 @@ print("")
     # start from scratch
 c.execute('''DROP TABLE IF EXISTS genes''')
     # create the table
-c.execute('''CREATE TABLE genes (id INTEGER PRIMARY KEY AUTOINCREMENT, start INT, end INT, length INT, gID TEXT, gene_type TEXT, gene_name TEXT)''')
+c.execute('''CREATE TABLE genes (id INTEGER PRIMARY KEY AUTOINCREMENT, start INT, end INT, length INT, gene_type TEXT, gene_name TEXT)''')
 
 # populate the table from a file
-insert = '''INSERT INTO genes (start,end,length,gID,gene_type,gene_name) VALUES(?,?,?,?,?,?)'''
+insert = '''INSERT INTO genes (start,end,length,gene_type,gene_name) VALUES(?,?,?,?,?)'''
 print("Creating genes table ...")
 
 # check if there is an annotations file in the project
@@ -321,7 +321,7 @@ if "annotations" in jsondata["data"]:
                         # optionally print out anything without a name
                         # print("No name found: {}".format(l))
 
-                    c.execute(insert, [v[3], v[4], length, values["ID"], values["biotype"], name]) 
+                    c.execute(insert, [v[3], v[4], length, values["biotype"], name]) 
 
 # ---------------------------------------------------------
 # if there is an annotations file, insert that data as well
@@ -333,7 +333,7 @@ if os.path.isfile(annotations_file):
     for e in df.to_dict(orient='records'):
         c.execute(insert, [ int(e['start']), int(e['end']), 
                             int(e['end']) - int(e['start']),
-                            e['id'], e['type'], e['name'] ] 
+                            e['type'], e['name'] ] 
                  )
 
 # ---------------------------------------------------------------------------

--- a/doc/files.md
+++ b/doc/files.md
@@ -1,7 +1,10 @@
 # The Project
 
+A project has the following expected structure:
+
 ```
 projectname/
+    project.json        (required. defines project data)
     source/
         annotations.csv (optional)
     generated/          (generated during project make/release)

--- a/doc/files.md
+++ b/doc/files.md
@@ -1,0 +1,24 @@
+# The Project
+
+```
+projectname/
+    source/
+        annotations.csv (optional)
+    generated/          (generated during project make/release)
+
+```
+
+# annotations.csv
+
+This is a csv file that the user can use to add annotations to the browser.
+
+The format is at least four columns: `name,start,end,type`. Additional columns can be added after these four, and they are ignored by the system.
+
+
+```
+name,start,end,type
+gene1-2,380000,420000,gene
+gene2-3,760000,840000,gene
+gene6,2200000,2300000,gene
+gene10-11,3800000,4200000,gene
+```

--- a/projects/test.00/source/annotations.csv
+++ b/projects/test.00/source/annotations.csv
@@ -1,5 +1,5 @@
-name,start,end,id,type,note
-gene1-2,380000,420000,gene1-2,gene,"segments 1,2"
-gene2-3,760000,840000,gene2-3,gene,"segments 2,3"
-gene6,2200000,2300000,gene6,gene,"segments 6"
-gene10-11,3800000,4200000,gene10-11,gene,"segments 10,11"
+name,start,end,type,note
+gene1-2,380000,420000,gene,"segments 1,2"
+gene2-3,760000,840000,gene,"segments 2,3"
+gene6,2200000,2300000,gene,"segments 6"
+gene10-11,3800000,4200000,gene,"segments 10,11"

--- a/server/gtkserver.py
+++ b/server/gtkserver.py
@@ -388,8 +388,8 @@ def GetGeneMetadata(name):
                 "start"     : results[0],
                 "end"       : results[1],
                 "length"    : results[2],
-                "gene_type" : results[4],
-                "gene_name" : results[5]
+                "gene_type" : results[3],
+                "gene_name" : results[4]
                 }
 
 

--- a/server/gtkserver.py
+++ b/server/gtkserver.py
@@ -370,17 +370,27 @@ def GetGeneMetadata(name):
     # return all genes
     conn = db_connect.connect()
 
-    query = conn.execute("SELECT start,end,length,gID,gene_type,gene_name from genes WHERE gene_name = ?", name)
+    query = conn.execute("SELECT start,end,length,gene_type,gene_name from genes WHERE gene_name = ?", name)
     results = query.cursor.fetchone()
 
+    # initialize
     data = {
-            "start"     : results[0],
-            "end"       : results[1],
-            "length"    : results[2],
-            "gID"       : results[3],
-            "gene_type" : results[4],
-            "gene_name" : results[5]
+            "start"     : None, 
+            "end"       : None,
+            "length"    : None,
+            "gene_type" : None,
+            "gene_name" : None
             }
+
+    # get data if it exists
+    if (results != None) :
+        data = {
+                "start"     : results[0],
+                "end"       : results[1],
+                "length"    : results[2],
+                "gene_type" : results[4],
+                "gene_name" : results[5]
+                }
 
 
     return jsonify(data)
@@ -489,7 +499,6 @@ def SegmentsForGene(names, structureid):
     for s in snames:
         query = conn.execute("SELECT start, end FROM genes WHERE gene_name == ?", s)
         results = query.cursor.fetchone()
-        # print("querying on :{}".format(s))
 
         if (results != None) :
             g_start = results[0]

--- a/testing/test_gene-query.py
+++ b/testing/test_gene-query.py
@@ -20,7 +20,6 @@ def test_gene_query():
                         'start'     : 3076875,
                         'end'       : 3078817,
                         'length'    : 1942,
-                        'gID'       : 'gene:ENSMUSG00000100249',
                         'gene_name' : 'Btbd35f23',
                         'gene_type' : 'protein_coding'
                     },
@@ -28,7 +27,6 @@ def test_gene_query():
                         'start'     : 3148912,
                         'end'       : 3150852,
                         'length'    : 1940,
-                        'gID'       : 'gene:ENSMUSG00000096426',
                         'gene_name' : 'Btbd35f24',
                         'gene_type' : 'protein_coding'
                     }
@@ -39,7 +37,6 @@ def test_gene_query():
                         'start'     : 151901782,
                         'end'       : 151915857,
                         'length'    : 14075,
-                        'gID'       : 'gene:ENSMUSG00000071665',
                         'gene_name' : 'Foxr2',
                         'gene_type' : 'protein_coding'
                     },
@@ -47,7 +44,6 @@ def test_gene_query():
                         'start'     : 151819162,
                         'end'       : 151820571,
                         'length'    : 1409,
-                        'gID'       : 'gene:ENSMUSG00000047238',
                         'gene_name' : 'Mageh1',
                         'gene_type' : 'protein_coding'
                     },
@@ -55,7 +51,6 @@ def test_gene_query():
                         'start'     : 151922977,
                         'end'       : 151954939,
                         'length'    : 31962,
-                        'gID'       : 'gene:ENSMUSG00000041658',
                         'gene_name' : 'Rragb',
                         'gene_type' : 'protein_coding'
                     }


### PR DESCRIPTION
Removing the 'gID' field from the database tables and all operations. This slims the table down to essentials, as the gID was never used.